### PR TITLE
fix: makefile ut does not run any tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ clean:
 UT_DB_TAGS ?= database,mysql
 
 ut:
-	go test -v $(go list ./src/... | grep -v './src/cmd' | grep -v './src/datastore/ent')
+	@PKGS=$$(go list ./src/... | grep -v './src/cmd' | grep -v './src/datastore/ent'); \
+	go test -v $$PKGS
 
 ut-db:
 	go test -v -tags=$(UT_DB_TAGS) ./src/service/...


### PR DESCRIPTION
```
ut:
  go test -v $(go list ./src/... | grep -v './src/cmd' | grep -v './src/datastore/ent')
```
make 默认不会用 shell 来解析 $(...)，而是当作 Make 的变量替换语法